### PR TITLE
Update extension.ts

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,7 @@ export class sqlFormatterClass {
     constructor() {}
 
     formatter() {
+        let editor = vscode.window.activeTextEditor;
         let text   = editor.document.getText();
 
         sqlChannel.append("---------------------------\n");


### PR DESCRIPTION
Updated formatter() to get the latest activeTextEditor

I'm not a js developer and I'm pretty sure this isn't the best way to do it, but it corrects this issue (the editor isn't being updated with the latest activeTextEdit when tab selection changes):

https://github.com/cymonbr/SqlFormatter-VSCode/issues/1